### PR TITLE
⚒️ Buildx

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,3 +77,4 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           target: ${{ inputs.target }}
           file: ${{ inputs.file }}
+          platforms: ${{ inputs.platforms }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,14 @@ on:
       tags:
         description: The tags to apply to the image
         type: string
+      buildx:
+        description: Whether to use buildx
+        type: boolean
+        default: false
+      platforms:
+        description: The build architecture platforms
+        type: string
+        default: linux/amd64
 
 jobs:
   build-and-push-image:
@@ -33,6 +41,18 @@ jobs:
     steps:
       - name: 📰 Checkout repository
         uses: actions/checkout@v3
+
+      - name: 🦤 Set up QEMU
+        if: ${{ inputs.buildx }}
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: ${{ inputs.platforms }}
+
+      - name: 📦 Setup Docker Buildx
+        if: ${{ inputs.buildx }}
+        uses: docker/setup-buildx-action@v2
+        with:
+          platforms: ${{ inputs.platforms }}
 
       - name: 🏷️ Extract metadata (tags, labels) for Docker
         id: meta

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,10 +10,17 @@ on:
       target:
         description: The docker image to target
         type: string
-      image_name: 
+      image_name:
         description: The name of the image to  publish
         type: string
         default: ${{ github.repository }}
+      file:
+        description: The Dockerfile to build
+        type: string
+        default: Dockerfile
+      tags:
+        description: The tags to apply to the image
+        type: string
 
 jobs:
   build-and-push-image:
@@ -32,6 +39,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: ${{ inputs.registry }}/${{ inputs.image_name }}
+          tags: ${{ inputs.tags }}
 
       - name: 🔏 Log in to the Container registry
         uses: docker/login-action@v2
@@ -48,3 +56,4 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           target: ${{ inputs.target }}
+          file: ${{ inputs.file }}


### PR DESCRIPTION
# Buildx
Adds support for `docker buildx`

Currently in use for [whisper-bot](https://github.com/WGBH-MLA/whisper-bot) building `ARM64` images on GitHub Actions