### PR TITLE
🪙 Token

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -22,10 +22,6 @@ on:
         description: Additional args to pass to pytest
         type: string
 
-    secrets:
-      token:
-        description: The token to upload the coverage report to codecov
-
 jobs:
   run_pytest:
     name: 🐍 Run pytest and upload coverage report
@@ -50,11 +46,8 @@ jobs:
         run: pytest --cov --cov-report lcov ${{ inputs.pytest_args }}
 
       - name: 📈 Uploade coverage report
-        # skip this step if no token present
         # run this step, even if the tests fail
-        env:
-          token: ${{ secrets.token }}
-        if: env.token != null && success() || failure()
+        if: success() || failure()
         uses: codecov/codecov-action@v3
         with:
-          token: ${{ secrets.token }}
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -43,7 +43,7 @@ jobs:
         run: pip install ${{ inputs.pip_args }}
 
       - name: 🧪 Run pytest suite
-        run: pytest --cov --cov-report lcov ${{ inputs.pytest_args }}
+        run: pytest --cov=. --cov-report lcov ${{ inputs.pytest_args }}
 
       - name: 📈 Uploade coverage report
         # run this step, even if the tests fail


### PR DESCRIPTION
# Token
Removes `token` input to pytest workflow

## Usage
Include `secrets: inherit` in caller workflow
```yml
jobs:
  tests:
    name: ⚗️ Application Tests
    uses: WGBH-MLA/.github/.github/workflows/pytest.yml@main
    secrets: inherit
    with:
      pytest_args: -n auto
```